### PR TITLE
feat: add env validation and storage adapters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
 lib64/
 parts/
 sdist/

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,10 @@
+import env from '../../../env.mjs';
+
+export async function GET() {
+  return new Response(
+    JSON.stringify({ storage: env.STORAGE_PROVIDER }),
+    {
+      headers: { 'Content-Type': 'application/json' },
+    }
+  );
+}

--- a/env.mjs
+++ b/env.mjs
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+
+const baseSchema = z.object({
+  OPENAI_API_KEY: z.string().min(1, 'OPENAI_API_KEY is required'),
+  STORAGE_PROVIDER: z.enum(['s3', 'r2', 'supabase']).default('s3')
+});
+
+const s3Schema = z.object({
+  S3_REGION: z.string().min(1),
+  S3_BUCKET: z.string().min(1),
+  S3_ACCESS_KEY: z.string().min(1),
+  S3_SECRET_KEY: z.string().min(1)
+});
+
+const r2Schema = z.object({
+  R2_ENDPOINT: z.string().url(),
+  R2_ACCOUNT_ID: z.string().min(1),
+  R2_BUCKET: z.string().min(1),
+  R2_ACCESS_KEY: z.string().min(1),
+  R2_SECRET_KEY: z.string().min(1)
+});
+
+const supabaseSchema = z.object({
+  SUPABASE_URL: z.string().url(),
+  SUPABASE_ANON: z.string().min(1),
+  SUPABASE_SERVICE_ROLE: z.string().min(1),
+  SUPABASE_BUCKET: z.string().min(1)
+});
+
+function getEnv() {
+  const base = baseSchema.parse(process.env);
+  switch (base.STORAGE_PROVIDER) {
+    case 'r2':
+      return { ...base, ...r2Schema.parse(process.env) };
+    case 'supabase':
+      return { ...base, ...supabaseSchema.parse(process.env) };
+    default:
+      return { ...base, ...s3Schema.parse(process.env) };
+  }
+}
+
+const env = getEnv();
+export default env;

--- a/lib/openai.ts
+++ b/lib/openai.ts
@@ -1,0 +1,8 @@
+import OpenAI from 'openai';
+import env from '../env.mjs';
+
+export const openai = new OpenAI({
+  apiKey: env.OPENAI_API_KEY,
+});
+
+export default openai;

--- a/lib/storage/index.ts
+++ b/lib/storage/index.ts
@@ -1,0 +1,16 @@
+import env from '../../env.mjs';
+import type { StorageAdapter } from './types';
+import s3 from './s3';
+import r2 from './r2';
+import supabase from './supabase';
+
+const adapters: Record<string, StorageAdapter> = {
+  s3,
+  r2,
+  supabase,
+};
+
+const storage = adapters[env.STORAGE_PROVIDER] ?? s3;
+
+export const uploadBuffer = storage.uploadBuffer;
+export const getPresignedUrl = storage.getPresignedUrl;

--- a/lib/storage/r2.ts
+++ b/lib/storage/r2.ts
@@ -1,0 +1,35 @@
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import env from '../../env.mjs';
+import type { StorageAdapter } from './types';
+
+const client = new S3Client({
+  region: 'auto',
+  endpoint: env.R2_ENDPOINT,
+  credentials: {
+    accessKeyId: env.R2_ACCESS_KEY,
+    secretAccessKey: env.R2_SECRET_KEY,
+  },
+});
+
+async function uploadBuffer(key: string, buffer: Buffer, mime: string) {
+  const cmd = new PutObjectCommand({
+    Bucket: env.R2_BUCKET,
+    Key: key,
+    Body: buffer,
+    ContentType: mime,
+  });
+  await client.send(cmd);
+}
+
+async function getPresignedUrl(key: string, mime: string, expires: number) {
+  const cmd = new PutObjectCommand({
+    Bucket: env.R2_BUCKET,
+    Key: key,
+    ContentType: mime,
+  });
+  return getSignedUrl(client, cmd, { expiresIn: expires });
+}
+
+const adapter: StorageAdapter = { uploadBuffer, getPresignedUrl };
+export default adapter;

--- a/lib/storage/s3.ts
+++ b/lib/storage/s3.ts
@@ -1,0 +1,34 @@
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import env from '../../env.mjs';
+import type { StorageAdapter } from './types';
+
+const client = new S3Client({
+  region: env.S3_REGION,
+  credentials: {
+    accessKeyId: env.S3_ACCESS_KEY,
+    secretAccessKey: env.S3_SECRET_KEY,
+  },
+});
+
+async function uploadBuffer(key: string, buffer: Buffer, mime: string) {
+  const cmd = new PutObjectCommand({
+    Bucket: env.S3_BUCKET,
+    Key: key,
+    Body: buffer,
+    ContentType: mime,
+  });
+  await client.send(cmd);
+}
+
+async function getPresignedUrl(key: string, mime: string, expires: number) {
+  const cmd = new PutObjectCommand({
+    Bucket: env.S3_BUCKET,
+    Key: key,
+    ContentType: mime,
+  });
+  return getSignedUrl(client, cmd, { expiresIn: expires });
+}
+
+const adapter: StorageAdapter = { uploadBuffer, getPresignedUrl };
+export default adapter;

--- a/lib/storage/supabase.ts
+++ b/lib/storage/supabase.ts
@@ -1,0 +1,23 @@
+import { createClient } from '@supabase/supabase-js';
+import env from '../../env.mjs';
+import type { StorageAdapter } from './types';
+
+const client = createClient(env.SUPABASE_URL, env.SUPABASE_SERVICE_ROLE);
+
+async function uploadBuffer(key: string, buffer: Buffer, mime: string) {
+  const { error } = await client.storage
+    .from(env.SUPABASE_BUCKET)
+    .upload(key, buffer, { contentType: mime, upsert: true });
+  if (error) throw error;
+}
+
+async function getPresignedUrl(key: string, _mime: string, expires: number) {
+  const { data, error } = await client.storage
+    .from(env.SUPABASE_BUCKET)
+    .createSignedUrl(key, expires);
+  if (error) throw error;
+  return data.signedUrl;
+}
+
+const adapter: StorageAdapter = { uploadBuffer, getPresignedUrl };
+export default adapter;

--- a/lib/storage/types.ts
+++ b/lib/storage/types.ts
@@ -1,0 +1,4 @@
+export interface StorageAdapter {
+  uploadBuffer: (key: string, buffer: Buffer, mime: string) => Promise<void>;
+  getPresignedUrl: (key: string, mime: string, expires: number) => Promise<string>;
+}


### PR DESCRIPTION
## Summary
- add Zod-based environment validation with storage-provider specific schemas
- initialize OpenAI client and unified storage interface for S3, R2, and Supabase
- expose storage provider via `/api/health`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a40df4df788322b2a2cf48a636581d