### PR TITLE
feat: add graph types and zustand store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
 lib64/
 parts/
 sdist/
@@ -29,6 +28,9 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+
+# Node
+node_modules/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -1,0 +1,39 @@
+import { create } from 'zustand';
+import { Artifact, Graph, NodeRun, RunStatus } from './types';
+
+type GraphStore = {
+  graph: Graph;
+  selectedNode?: string;
+  artifacts: Record<string, Artifact>;
+  runs: Record<string, NodeRun>;
+  setGraph: (graph: Graph) => void;
+  selectNode: (nodeId?: string) => void;
+  setArtifact: (nodeId: string, artifact: Artifact) => void;
+  setRunStatus: (nodeId: string, status: RunStatus) => void;
+};
+
+export const useGraphStore = create<GraphStore>((set) => ({
+  graph: { nodes: [], edges: [] },
+  selectedNode: undefined,
+  artifacts: {},
+  runs: {},
+  setGraph: (graph) => set({ graph }),
+  selectNode: (nodeId) => set({ selectedNode: nodeId }),
+  setArtifact: (nodeId, artifact) =>
+    set((state) => ({
+      artifacts: { ...state.artifacts, [nodeId]: artifact },
+    })),
+  setRunStatus: (nodeId, status) =>
+    set((state) => ({
+      runs: {
+        ...state.runs,
+        [nodeId]: { ...(state.runs[nodeId] ?? { status }), status },
+      },
+    })),
+}));
+
+// temporary dummy artifact for panel visibility
+useGraphStore.getState().setArtifact('demo-node', {
+  type: 'ocr',
+  content: 'Dummy artifact for preview',
+});

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod';
+
+export const ArtifactType = z.enum(['ocr', 'storyboard', 'manim_py', 'video']);
+
+export const ArtifactSchema = z.object({
+  type: ArtifactType,
+  url: z.string().url().optional(),
+  content: z.unknown().optional(),
+});
+export type Artifact = z.infer<typeof ArtifactSchema>;
+
+export const RunStatusEnum = z.enum(['idle', 'running', 'success', 'error']);
+export type RunStatus = z.infer<typeof RunStatusEnum>;
+
+export const NodeRunSchema = z.object({
+  status: RunStatusEnum,
+  startedAt: z.date().optional(),
+  finishedAt: z.date().optional(),
+});
+export type NodeRun = z.infer<typeof NodeRunSchema>;
+
+export const NodeType = ArtifactType;
+
+export const NodeSchema = z.object({
+  id: z.string(),
+  type: NodeType,
+  data: z.record(z.unknown()).optional(),
+});
+export type Node = z.infer<typeof NodeSchema>;
+
+export const EdgeSchema = z.object({
+  id: z.string(),
+  source: z.string(),
+  target: z.string(),
+});
+export type Edge = z.infer<typeof EdgeSchema>;
+
+export const GraphSchema = z.object({
+  nodes: z.array(NodeSchema),
+  edges: z.array(EdgeSchema),
+});
+export type Graph = z.infer<typeof GraphSchema>;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "manimator-web",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "test": "tsc --noEmit"
+  },
+  "dependencies": {
+    "zustand": "^4.5.0",
+    "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["lib/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- define zod schemas for artifacts, runs, nodes and edges
- add zustand graph store with helpers and demo artifact

## Testing
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/typescript)
- `npm test` (fails: Cannot find module 'zustand' or its corresponding type declarations)

------
https://chatgpt.com/codex/tasks/task_e_68a40de073d88322b964f6aa3e67810a