### PR TITLE
feat: add base node UI with toolbar and status

### DIFF
--- a/frontend/src/hooks/useRightPanel.ts
+++ b/frontend/src/hooks/useRightPanel.ts
@@ -1,0 +1,8 @@
+export const useRightPanel = () => {
+  const switchTab = (tab: string) => {
+    console.log(`Switching right panel to ${tab}`);
+  };
+  return { switchTab };
+};
+
+export default useRightPanel;

--- a/frontend/src/nodes/BaseNode.tsx
+++ b/frontend/src/nodes/BaseNode.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Handle, Position, NodeToolbar, NodeProps } from 'reactflow';
+import useRightPanel from '../hooks/useRightPanel';
+
+export type NodeStatus = 'idle' | 'generating' | 'error' | 'done';
+
+const statusColor: Record<NodeStatus, string> = {
+  idle: 'gray',
+  generating: 'blue',
+  error: 'red',
+  done: 'green',
+};
+
+interface BaseNodeProps extends NodeProps {
+  status?: NodeStatus;
+}
+
+const BaseNode: React.FC<BaseNodeProps> = ({ status = 'idle', data }) => {
+  const { switchTab } = useRightPanel();
+
+  const handleToolbarClick = (tab: string) => () => switchTab(tab);
+
+  return (
+    <div style={{ position: 'relative', padding: 10 }}>
+      <div
+        style={{
+          width: 10,
+          height: 10,
+          borderRadius: '50%',
+          backgroundColor: statusColor[status],
+          position: 'absolute',
+          top: 2,
+          left: 2,
+        }}
+      />
+      {data?.label && <div style={{ marginLeft: 16 }}>{data.label}</div>}
+
+      <NodeToolbar isVisible position={Position.Top} style={{ display: 'flex', gap: 4 }}>
+        <button onClick={handleToolbarClick('regenerate')}>재생성</button>
+        <button onClick={handleToolbarClick('edit')}>편집 열기</button>
+        <button onClick={handleToolbarClick('history')}>히스토리</button>
+      </NodeToolbar>
+
+      <Handle type="source" position={Position.Right} />
+    </div>
+  );
+};
+
+export default BaseNode;


### PR DESCRIPTION
## Summary
- add a reusable base node component with status dot and toolbar actions
- include a right-panel hook that logs tab changes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a40ddaf6108322af0992d6865c44f7