### PR TITLE
feat: add inspector component

### DIFF
--- a/frontend/Inspector.tsx
+++ b/frontend/Inspector.tsx
@@ -1,0 +1,86 @@
+import { useState } from 'react';
+import Editor, { DiffEditor } from '@monaco-editor/react';
+import { useInspectorStore } from './store';
+
+export default function Inspector() {
+  const { artifact, setArtifact, prompt, setPrompt, history } = useInspectorStore();
+  const [activeTab, setActiveTab] = useState<'result' | 'prompt' | 'history'>('result');
+  const [showDiff, setShowDiff] = useState(false);
+  const [draft, setDraft] = useState(artifact.modified);
+
+  const saveDraft = () => {
+    setArtifact({ original: artifact.original, modified: draft });
+  };
+
+  return (
+    <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+      <div style={{ display: 'flex', borderBottom: '1px solid #ccc' }}>
+        <button onClick={() => setActiveTab('result')}>Result</button>
+        <button onClick={() => setActiveTab('prompt')}>Prompt</button>
+        <button onClick={() => setActiveTab('history')}>History</button>
+      </div>
+      <div style={{ flex: 1 }}>
+        {activeTab === 'result' && (
+          <div style={{ height: '100%' }}>
+            <div style={{ marginBottom: '8px' }}>
+              <label>
+                <input
+                  type="checkbox"
+                  checked={showDiff}
+                  onChange={(e) => setShowDiff(e.target.checked)}
+                />
+                Original ↔ Modified Diff
+              </label>
+              <button onClick={saveDraft}>Save/Apply</button>
+            </div>
+            {showDiff ? (
+              <DiffEditor
+                original={artifact.original}
+                modified={draft}
+                onChange={(v) => setDraft(v || '')}
+                height="80vh"
+                language="javascript"
+              />
+            ) : (
+              <Editor
+                value={draft}
+                onChange={(v) => setDraft(v || '')}
+                height="80vh"
+                language="javascript"
+              />
+            )}
+          </div>
+        )}
+        {activeTab === 'prompt' && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', padding: '8px' }}>
+            <input
+              placeholder="System"
+              value={prompt.system}
+              onChange={(e) => setPrompt({ ...prompt, system: e.target.value })}
+            />
+            <input
+              placeholder="User"
+              value={prompt.user}
+              onChange={(e) => setPrompt({ ...prompt, user: e.target.value })}
+            />
+            <input
+              placeholder="Data"
+              value={prompt.data}
+              onChange={(e) => setPrompt({ ...prompt, data: e.target.value })}
+            />
+          </div>
+        )}
+        {activeTab === 'history' && (
+          <ul>
+            {history.map((run) => (
+              <li key={run.id}>
+                {run.label}
+                {/* Placeholder for artifact comparison button */}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/store.ts
+++ b/frontend/store.ts
@@ -1,0 +1,34 @@
+import { create } from 'zustand';
+
+export interface Artifact {
+  original: string;
+  modified: string;
+}
+
+interface PromptFields {
+  system: string;
+  user: string;
+  data: string;
+}
+
+interface NodeRun {
+  id: string;
+  label: string;
+  artifact: Artifact;
+}
+
+interface InspectorState {
+  artifact: Artifact;
+  prompt: PromptFields;
+  history: NodeRun[];
+  setArtifact: (artifact: Artifact) => void;
+  setPrompt: (prompt: PromptFields) => void;
+}
+
+export const useInspectorStore = create<InspectorState>((set) => ({
+  artifact: { original: '', modified: '' },
+  prompt: { system: '', user: '', data: '' },
+  history: [],
+  setArtifact: (artifact: Artifact) => set({ artifact }),
+  setPrompt: (prompt: PromptFields) => set({ prompt }),
+}));


### PR DESCRIPTION
## Summary
- create Inspector component with tabs for result, prompt, history
- support Monaco editing with diff and saving to shared store
- add Zustand store to manage artifact, prompt, and history state

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a40de6a2c88322b3790e3d801f60b2