### PR TITLE
feat: generate storyboard from OCR

### DIFF
--- a/lib/storyboard.ts
+++ b/lib/storyboard.ts
@@ -1,0 +1,57 @@
+import { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
+import openai from './openai';
+import { Storyboard, StoryboardSchema } from './types';
+import { uploadBuffer } from './storage';
+import { randomUUID } from 'crypto';
+
+export interface StoryboardOptions {
+  tone?: string;
+  length?: string;
+  sceneCount?: number;
+}
+
+export interface GenerateStoryboardInput {
+  ocrJson: unknown;
+  options?: StoryboardOptions;
+  system?: string;
+  user?: string;
+  data?: string;
+}
+
+/**
+ * Generate a storyboard from OCR JSON and options.
+ * Combines system, user and data prompts for the LLM call and
+ * stores the resulting storyboard as an artifact.
+ */
+export async function generateStoryboard({
+  ocrJson,
+  options = {},
+  system = '',
+  user = '',
+  data = '',
+}: GenerateStoryboardInput): Promise<{ artifactId: string; json: Storyboard }> {
+  const messages: ChatCompletionMessageParam[] = [];
+  if (system) {
+    messages.push({ role: 'system', content: system });
+  }
+  const userContent = [user, data, JSON.stringify({ ocr: ocrJson, options })]
+    .filter(Boolean)
+    .join('\n');
+  messages.push({ role: 'user', content: userContent });
+
+  const completion = await openai.chat.completions.create({
+    model: 'gpt-4o-mini',
+    messages,
+  });
+  const content = completion.choices[0]?.message?.content ?? '{}';
+  const json = StoryboardSchema.parse(JSON.parse(content));
+
+  const artifactId = `storyboards/${randomUUID()}.json`;
+  await uploadBuffer(
+    artifactId,
+    Buffer.from(JSON.stringify(json), 'utf-8'),
+    'application/json'
+  );
+
+  return { artifactId, json };
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -40,3 +40,20 @@ export const GraphSchema = z.object({
   edges: z.array(EdgeSchema),
 });
 export type Graph = z.infer<typeof GraphSchema>;
+
+// Storyboard scene schema
+export const SceneSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  start: z.number(),
+  end: z.number(),
+  narration: z.string(),
+  equations: z.array(z.string()),
+  visuals: z.array(z.string()),
+});
+export type Scene = z.infer<typeof SceneSchema>;
+
+export const StoryboardSchema = z.object({
+  scenes: z.array(SceneSchema),
+});
+export type Storyboard = z.infer<typeof StoryboardSchema>;

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "test": "tsc --noEmit"
   },
   "dependencies": {
+    "openai": "^4.56.1",
     "zustand": "^4.5.0",
     "zod": "^3.22.4"
   },


### PR DESCRIPTION
## Summary
- add storyboard schemas
- implement generateStoryboard to call OpenAI and save JSON artifact
- include openai dependency

## Testing
- `npm test` *(fails: Cannot find module 'openai' and other dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a45c48183c8322aa7da6903b852ed5