### PR TITLE
feat: render manim scenes via docker

### DIFF
--- a/app/api/render/route.ts
+++ b/app/api/render/route.ts
@@ -1,0 +1,37 @@
+import fs from 'fs/promises';
+import path from 'path';
+import DockerManimRunner from '../../../worker/DockerManimRunner';
+import { getPresignedUrl } from '../../../lib/storage';
+
+export async function POST(req: Request) {
+  try {
+    const { code, sceneName = 'MainScene', quality = 'ql', artifactId } = await req.json();
+
+    let source = code as string | undefined;
+    if (!source && artifactId) {
+      const filePath = path.join(process.cwd(), 'artifacts', `${artifactId}.py`);
+      source = await fs.readFile(filePath, 'utf-8');
+    }
+
+    if (!source) {
+      return new Response(
+        JSON.stringify({ error: 'No code provided' }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const { key } = await DockerManimRunner.render({ code: source, sceneName, quality });
+    const url = await getPresignedUrl(key, 'video/mp4', 3600);
+
+    return new Response(
+      JSON.stringify({ videoKey: key, videoUrl: url }),
+      { headers: { 'Content-Type': 'application/json' } }
+    );
+  } catch (error) {
+    console.error('render error', error);
+    return new Response(
+      JSON.stringify({ error: 'Failed to render video' }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+}

--- a/lib/env.d.ts
+++ b/lib/env.d.ts
@@ -3,3 +3,12 @@ declare module '../env.mjs' {
   export default env;
 }
 
+declare module '../../env.mjs' {
+  const env: any;
+  export default env;
+}
+
+declare module '*env.mjs' {
+  const env: any;
+  export default env;
+}

--- a/lib/storyboard.ts
+++ b/lib/storyboard.ts
@@ -1,8 +1,12 @@
-import { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
 import openai from './openai';
 import { Storyboard, StoryboardSchema } from './types';
 import { uploadBuffer } from './storage';
 import { randomUUID } from 'crypto';
+
+interface ChatMessage {
+  role: string;
+  content: string;
+}
 
 export interface StoryboardOptions {
   tone?: string;
@@ -30,7 +34,7 @@ export async function generateStoryboard({
   user = '',
   data = '',
 }: GenerateStoryboardInput): Promise<{ artifactId: string; json: Storyboard }> {
-  const messages: ChatCompletionMessageParam[] = [];
+  const messages: ChatMessage[] = [];
   if (system) {
     messages.push({ role: 'system', content: system });
   }

--- a/worker/DockerManimRunner.ts
+++ b/worker/DockerManimRunner.ts
@@ -1,0 +1,52 @@
+import { randomUUID } from 'crypto';
+import fs from 'fs/promises';
+import path from 'path';
+import util from 'util';
+import { exec as execCallback } from 'child_process';
+import { uploadBuffer } from '../lib/storage';
+
+const exec = util.promisify(execCallback);
+
+export interface RenderOptions {
+  code: string;
+  sceneName: string;
+  quality?: string; // e.g. 'ql', 'qh'
+}
+
+export default class DockerManimRunner {
+  static async render({ code, sceneName, quality = 'ql' }: RenderOptions) {
+    const id = randomUUID();
+    const workDir = path.join('/tmp', `manim-${id}`);
+    await fs.mkdir(workDir, { recursive: true });
+
+    const scriptPath = path.join(workDir, 'scene.py');
+    await fs.writeFile(scriptPath, code, 'utf-8');
+
+    const outputFile = 'output.mp4';
+    const image = process.env.MANIM_IMAGE || 'manimcommunity/manim:latest';
+
+    const cmd = [
+      'docker run --rm',
+      `-v ${workDir}:/manim`,
+      image,
+      'manim',
+      `-p${quality}`,
+      'scene.py',
+      sceneName,
+      '--format=mp4',
+      '-o',
+      outputFile,
+    ].join(' ');
+
+    await exec(cmd, { cwd: workDir });
+
+    const videoPath = path.join(workDir, outputFile);
+    const buffer = await fs.readFile(videoPath);
+    const key = `renders/${id}.mp4`;
+    await uploadBuffer(key, buffer, 'video/mp4');
+
+    await fs.rm(workDir, { recursive: true, force: true });
+
+    return { key };
+  }
+}


### PR DESCRIPTION
## Summary
- add DockerManimRunner to render Manim scenes via local Docker image and upload results to storage
- expose POST /api/render to run Manim code or saved artifact and return S3 key plus presigned URL
- fix storyboard types and env declarations for TypeScript

## Testing
- `npm install @aws-sdk/client-s3 @aws-sdk/s3-request-presigner @supabase/supabase-js` *(fails: 403 Forbidden)*
- `npm test` *(fails: cannot find @aws-sdk and supabase packages)*
- `npx tsc worker/DockerManimRunner.ts app/api/render/route.ts --noEmit --skipLibCheck` *(fails: missing module types)*

------
https://chatgpt.com/codex/tasks/task_e_68a4607bd3048322b56a7f1e61ec6e0d